### PR TITLE
Modified ND_Selection::plantBrick to return object of type "fxDTSBrick" or null

### DIFF
--- a/GameMode_CityRPG4/server/package.cs
+++ b/GameMode_CityRPG4/server/package.cs
@@ -51,6 +51,7 @@ package CityRPG_MainPackage
 		}
 
 		City_OnPlant(%brick);
+		return %brick;
 	}
 
 	function fxDTSBrick::onPlant(%brick)


### PR DESCRIPTION
NewDuplicator\classes\server\selection.cs | ND_Selection::tickPlantSearch() is expecting object of type fxDTSBrick
We were returning an object of type fxDTSBrickData