### PR TITLE
Fixed errors on first spawn

### DIFF
--- a/GameMode_CityRPG4/server/package.cs
+++ b/GameMode_CityRPG4/server/package.cs
@@ -633,6 +633,9 @@ package CityRPG_MainPackage
 
 		parent::spawnPlayer(%client);
 
+		if(!CityRPGData.getData(%client.bl_id))
+			return;
+
 		if(%client.moneyOnSuicide > 0)
 		{
 			CityRPGData.getData(%client.bl_id).valueMoney = %client.moneyOnSuicide;

--- a/GameMode_CityRPG4/server/player.cs
+++ b/GameMode_CityRPG4/server/player.cs
@@ -580,7 +580,8 @@ function jobset(%client, %job, %name)
 function resetFree(%client)
 {
 	%client.cityLog("***Account auto-reset***");
-	CityRPGData.removeData(%client.bl_id);
+	if(CityRPGData.getData(%client.bl_id))
+		CityRPGData.removeData(%client.bl_id);
 	CityRPGData.addData(%client.bl_id);
 
 	CityRPGData.getData(%client.bl_id).valueBank = 250;


### PR DESCRIPTION
It tried to use a client's CityRPGData before said data is created.
When resetting a player, it tried to remove data that does not exist.